### PR TITLE
Add a filtering checkbox on the Receivables Aging window; requires mods to the metaSQL.

### DIFF
--- a/guiclient/displays/dspTimePhasedOpenARItems.cpp
+++ b/guiclient/displays/dspTimePhasedOpenARItems.cpp
@@ -93,6 +93,12 @@ bool dspTimePhasedOpenARItems::setParams(ParameterList &params)
   params.append("useDocDate",  QVariant(_useDocDate->isChecked()));
   params.append("useDistDate", QVariant(_useDistDate->isChecked()));
 
+  if (_excludeNegs->isChecked())
+  {
+    params.append("no_creditMemo", "");
+    params.append("no_cashdeposit", "");
+  }
+
   return true;
 }
 

--- a/guiclient/displays/dspTimePhasedOpenARItems.ui
+++ b/guiclient/displays/dspTimePhasedOpenARItems.ui
@@ -66,6 +66,47 @@ to be bound by its terms.</comment>
      </layout>
     </widget>
    </item>
+   <item row="1" column="1">
+    <widget class="QGroupBox" name="_filterGroup">
+     <property name="title">
+      <string>Filters</string>
+     </property>
+     <layout class="QHBoxLayout">
+      <property name="leftMargin">
+       <number>3</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>3</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="XCheckBox" name="_excludeNegs">
+        <property name="text">
+         <string>Exclude Customer Deposits and Credit Memos</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>28</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item row="2" column="0">
     <widget class="QGroupBox" name="_useGroup">
      <property name="title">


### PR DESCRIPTION
The full changes (two files) to create and implement a filtering checkbox on the Receivables Aging window. Note that for the code to have any impact, the metaSQL for "arAging" also needs to have additional WHERE conditions added for at least the following parameters:

<? if exists("no_creditMemo") ?>
AND (araging_doctype <> 'C')
<? endif ?>
<? if exists("no_cashdeposit") ?>
AND (araging_doctype <> 'R')
<? endif ?>